### PR TITLE
Replacing __dirname with process.cwd()

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const { sync: loadPostcssConfig } = require('postcss-load-config')
 module.exports = opts => {
 	// prepare configuration
 	const pcssConfigCtx = { cwd: __dirname, env: process.env.NODE_ENV }
-	const pcssConfigPath = __dirname
+	const pcssConfigPath = process.cwd()
 	const pcssConfig = safelyLoadPostcssConfig(pcssConfigCtx, pcssConfigPath, opts)
 
 	// rescript configuration used when no PostCSS configuration is present


### PR DESCRIPTION
There are cases (like when you use Yarn workspaces) where the config files cannot be properly resolved using `__dirname`. This will make the lookup based on `process.cwd()` which looks to be resolving for both cases.

Thanks for this great plugin, tho!